### PR TITLE
feat: update release-please config to exclude component tag

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "include-component-in-tag": false,
   "packages": {
     ".": {
       "release-type": "node",


### PR DESCRIPTION
Add "include-component-in-tag" option set to false in the 
release-please configuration to prevent appending the component 
name in the release tags. This change streamlines versioning 
when releasing packages.